### PR TITLE
Fix memory leak when rendering non-flat advanced info panels

### DIFF
--- a/src/main/java/com/zuxelus/energycontrol/renderers/CubeRenderer.java
+++ b/src/main/java/com/zuxelus/energycontrol/renderers/CubeRenderer.java
@@ -14,6 +14,10 @@ public class CubeRenderer {
 	private int displayList;
 	private CubeBox cube;
 	
+	public int getDisplayList() {
+		return displayList;
+	}
+	
 	public CubeRenderer(int faceOffsetX, int faceOffsetY) {
 		this(0.0F, 0.0F, 0.0F, 32, 32, 32, 128, 192, faceOffsetX, faceOffsetY);
 	}

--- a/src/main/java/com/zuxelus/energycontrol/renderers/TEAdvancedInfoPanelExtenderRenderer.java
+++ b/src/main/java/com/zuxelus/energycontrol/renderers/TEAdvancedInfoPanelExtenderRenderer.java
@@ -7,6 +7,7 @@ import com.zuxelus.energycontrol.tileentities.Screen;
 import com.zuxelus.energycontrol.tileentities.TileEntityAdvancedInfoPanel;
 import com.zuxelus.energycontrol.tileentities.TileEntityAdvancedInfoPanelExtender;
 
+import net.minecraft.client.renderer.GLAllocation;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
@@ -78,20 +79,25 @@ public class TEAdvancedInfoPanelExtenderRenderer extends TileEntitySpecialRender
 			thickness = 16;
 		int rotateHor = te.getRotateHor() / 7;
 		int rotateVert = te.getRotateVert() / 7;
-		Screen screen = te.getScreen();
-		if (screen == null) {
-			if (thickness == 16 && rotateHor == 0 && rotateVert == 0)
-				model[textureId].render(0.03125F);
-		} else {
-			if (thickness == 16 && rotateHor == 0 && rotateVert == 0)
-				model[textureId].render(0.03125F);
-			else {
-				RotationOffset offset = new RotationOffset(thickness * 2, rotateHor, rotateVert);
-				new CubeRenderer(textureId / 4 * 32 + 64, textureId % 4 * 32 + 64, offset.addOffset(screen, te.xCoord, te.yCoord, te.zCoord, te.getFacingForge(), te.getRotation())).render(0.03125F);
-			}
+	Screen screen = te.getScreen();
+	CubeRenderer dynamicRenderer = null;
+	if (screen == null) {
+		if (thickness == 16 && rotateHor == 0 && rotateVert == 0)
+			model[textureId].render(0.03125F);
+	} else {
+		if (thickness == 16 && rotateHor == 0 && rotateVert == 0)
+			model[textureId].render(0.03125F);
+		else {
+			RotationOffset offset = new RotationOffset(thickness * 2, rotateHor, rotateVert);
+			dynamicRenderer = new CubeRenderer(textureId / 4 * 32 + 64, textureId % 4 * 32 + 64, offset.addOffset(screen, te.xCoord, te.yCoord, te.zCoord, te.getFacingForge(), te.getRotation()));
+			dynamicRenderer.render(0.03125F);
 		}
-		GL11.glPopMatrix();
 	}
+	if (dynamicRenderer != null) {
+		GLAllocation.deleteDisplayLists(dynamicRenderer.getDisplayList());
+	}
+	GL11.glPopMatrix();
+}
 
 	@Override
 	public void renderTileEntityAt(TileEntity te, double x, double y, double z, float partialTicks) {

--- a/src/main/java/com/zuxelus/energycontrol/renderers/TEAdvancedInfoPanelRenderer.java
+++ b/src/main/java/com/zuxelus/energycontrol/renderers/TEAdvancedInfoPanelRenderer.java
@@ -10,6 +10,7 @@ import com.zuxelus.energycontrol.tileentities.Screen;
 import com.zuxelus.energycontrol.tileentities.TileEntityAdvancedInfoPanel;
 
 import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.renderer.GLAllocation;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
@@ -97,20 +98,27 @@ public class TEAdvancedInfoPanelRenderer extends TileEntitySpecialRenderer {
 		int rotateHor = te.rotateHor / 7;
 		int rotateVert = te.rotateVert / 7;
 		RotationOffset offset = new RotationOffset(thickness * 2, rotateHor, rotateVert);
-		Screen screen = te.getScreen();
-		if (screen != null) {
-			if (thickness == 16 && rotateHor == 0 && rotateVert == 0)
-				model[textureId].render(0.03125F);
-			else
-				new CubeRenderer(textureId / 4 * 32 + 64, textureId % 4 * 32 + 64, offset.addOffset(screen, te.xCoord, te.yCoord, te.zCoord, te.getFacingForge(), te.getRotation())).render(0.03125F);
-			if (te.powered) {
-				List<PanelString> joinedData = te.getPanelStringList(false, te.getShowLabels());
-				if (joinedData != null)
-					drawText(te, joinedData, thickness, offset);
-			}
+	Screen screen = te.getScreen();
+	CubeRenderer dynamicRenderer = null;
+	if (screen != null) {
+		if (thickness == 16 && rotateHor == 0 && rotateVert == 0)
+			model[textureId].render(0.03125F);
+		else {
+			dynamicRenderer = new CubeRenderer(textureId / 4 * 32 + 64, textureId % 4 * 32 + 64, offset.addOffset(screen, te.xCoord, te.yCoord, te.zCoord, te.getFacingForge(), te.getRotation()));
+			dynamicRenderer.render(0.03125F);
 		}
-		GL11.glPopMatrix();
+		if (te.powered) {
+			List<PanelString> joinedData = te.getPanelStringList(false, te.getShowLabels());
+			if (joinedData != null)
+				drawText(te, joinedData, thickness, offset);
+		}
+		
+		if (dynamicRenderer != null) {
+			GLAllocation.deleteDisplayLists(dynamicRenderer.getDisplayList());
+		}
 	}
+	GL11.glPopMatrix();
+}
 
 	@SuppressWarnings("incomplete-switch")
 	private void drawText(TileEntityAdvancedInfoPanel panel, List<PanelString> joinedData, byte thickness, RotationOffset offset) {


### PR DESCRIPTION
This may be a bit wrong solution, but at least you know where's the issue